### PR TITLE
318 (or 308) bytes

### DIFF
--- a/mona.s
+++ b/mona.s
@@ -163,7 +163,7 @@ Main:
 
 	; initialize the direction by pushing $00
 	phd
-	; initialize the high byte of the seed
+	; initialize the upper 16 bits of the seed
 	pea $7ec8
 
 next_part:

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-"Mona in 338 (or alternatively 328) bytes"
+"Mona in 318 (or alternatively 308) bytes"
 A small SNES demo by Revenant/Resistance
    slight size optimization by forarslys
 Made in a weekend for Demosplash 2019, Pittsburgh, PA, USA
@@ -6,8 +6,8 @@ Made in a weekend for Demosplash 2019, Pittsburgh, PA, USA
 This is a remake/port of an original 250-byte Atari XL demo by Ilmenit:
 http://www.pouet.net/prod.php?which=62917
 
-The original Atari version uses 250 bytes; this version uses exactly 338 (or 328)
-(128 bytes data + 208 (or 198) bytes code + 2-byte reset vector). Similar to the
+The original Atari version uses 250 bytes; this version uses exactly 318 (or 308)
+(128 bytes data + 188 (or 178) bytes code + 2-byte reset vector). Similar to the
 C64 port by Graham/Oxyron, this version is slightly larger than the original
 due to a lack of built-in screen/graphics routines on the SNES.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,12 +1,13 @@
-"Mona in 345 bytes"
+"Mona in 338 (or alternatively 328) bytes"
 A small SNES demo by Revenant/Resistance
+   slight size optimization by forarslys
 Made in a weekend for Demosplash 2019, Pittsburgh, PA, USA
 
 This is a remake/port of an original 250-byte Atari XL demo by Ilmenit:
 http://www.pouet.net/prod.php?which=62917
 
-The original Atari version uses 250 bytes; this version uses exactly 345
-(128 bytes data + 215 bytes code + 2-byte reset vector). Similar to the
+The original Atari version uses 250 bytes; this version uses exactly 338 (or 328)
+(128 bytes data + 208 (or 198) bytes code + 2-byte reset vector). Similar to the
 C64 port by Graham/Oxyron, this version is slightly larger than the original
 due to a lack of built-in screen/graphics routines on the SNES.
 


### PR DESCRIPTION
I saved bytes to 337 or 332 bytes.
The former is to obtain (seemingly) the exact same image as the original demo. The latter used your waiting-vblank method to save more bytes at the cost of several pixels remaining unupdated. (I just noticed them by comparing the your youtube video and the image from the codegolf page.)

I tested the former one with the real hardware and at least it worked.

![small](https://user-images.githubusercontent.com/40643786/68600828-8941c700-04e6-11ea-9fad-fa643cc8c2cf.JPG)

As a side note, the background initialization did not seem to always work?

![wrongcolor](https://user-images.githubusercontent.com/40643786/68601164-23a20a80-04e7-11ea-9738-f183d0889bed.JPG)

I just powered on and off the console to get the first image. (The reboot with the reset button never initialized the color correctly.)